### PR TITLE
Add params for DryRun and keeping N images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ These instructions will allow you to run the PowerShell script. This script can 
 ## Prerequisites
 * You need an Azure Service Principal Account with key to authenticate to Azure Container Registry.
 * You need to have Azure CLI and PowerShell installed on the machine, where you are running the script
-* This script works on the assumption that docker images tags based on $(SomeName)_$(Date:yyyyMMdd)$(Rev:.r)  
+* The NoOfDays argument works on the assumption that docker images tags based on $(SomeName)_$(Date:yyyyMMdd)$(Rev:.r)
+* Alternatively, the NoOfKeptImages argument is based on the date the image was last modified.
 
 ## Parameters
 * ServicePrincipalId - This is a required parameter. You need to provide service principal account id for this.
@@ -16,6 +17,7 @@ These instructions will allow you to run the PowerShell script. This script can 
 * SubscriptionName - This is not a required parameter. If service account is associated with only one subscription, then you do not need to provide this. If not, this can be used to set the context in which container registry is located.
 * AzureRegistryName - This is a required parameter. You need to provide name of the Azure Container Registry.
 * NoOfDays - This is not a required parameter. The script will clear docker images older than provided value for this parameter. By default, the value is 30 days.
+* NoOfKeptImages - This is not a required parameter.  The script will order images in each repository by date modified, then remove the oldest items beyond the number specified.
 
 ## Examples
 * Example 1:
@@ -32,3 +34,8 @@ In this case, script will delete the docker images older than 30 days for every 
 .\acr-cleanup.ps1 -ServicePrincipalId db27d2f6-b339-4918-856f-ca0e5c8d0ab5 -ServicePrincipalPass 67cc2733-69c9-46ee-b4d2-d679ceaf77ed -ServicePrincipalTenant fc334bf1-d9f9-4880-85a3-404c7c479c91 -AzureRegistryName my-azure-registry
 
 In this case, script will delete the docker images older than 30 days for every repo in the provided container registry.
+
+* Example 4:
+.\acr-cleanup.ps1 -ServicePrincipalId db27d2f6-b339-4918-856f-ca0e5c8d0ab5 -ServicePrincipalPass 67cc2733-69c9-46ee-b4d2-d679ceaf77ed -ServicePrincipalTenant fc334bf1-d9f9-4880-85a3-404c7c479c91 -AzureRegistryName my-azure-registry -NoOfKeptImages 5
+
+In this case, script will keep the 5 most recent docker images for every repo in the provided container registry.  Each repo will have no more than 5 images after executing.

--- a/acr-cleanup.ps1
+++ b/acr-cleanup.ps1
@@ -30,8 +30,40 @@ Param(
     # Gets no of days from user; images older than this will be removed
     [Parameter (Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
-    [String] $NoOfDays = "30"
+    [String] $NoOfDays = "30",
+
+    # Gets no of images to keep from user; images older than this will be removed
+    [Parameter (Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [String] $NoOfKeptImages,
+
+    # Allow the user to see what the script would have done, without actually deleting anything
+    [Parameter (Mandatory=$false)]
+    [bool] $DryRun = $false
 )
+
+Function Remove-Image {
+    param(
+    # Parameter help description
+    [Parameter(Mandatory=$true)]
+    [string]
+    $registryName,
+    [Parameter(Mandatory=$true)]
+    [string]
+    $imageName, 
+    [Parameter(Mandatory=$false)]
+    [bool]
+    $dryRun=$false
+    )
+
+    if($dryRun){
+        Write-Host "Would have deleted $imageName"
+    }
+    else {
+        Write-Host "Proceeding to delete image: $imageName"
+        az acr repository delete --name $registryName --image $imageName --yes
+    }
+}
 
 Write-Host "Establishing authentication with Azure..."
 az login --service-principal -u $ServicePrincipalId -p $ServicePrincipalPass --tenant $ServicePrincipalTenant
@@ -41,33 +73,44 @@ if ($SubscriptionName){
     az account set --subscription $SubscriptionName
 }
 
-
 Write-Host "Checking registry: $AzureRegistryName"
 $RepoList = az acr repository list --name $AzureRegistryName --output table
 for($index=2; $index -lt $RepoList.length; $index++){
     $RepositoryName = $RepoList[$index]
 
     Write-Host "Checking for repository: $RepositoryName"
-    $RepositoryTags = az acr repository show-tags --name $AzureRegistryName --repository $RepositoryName --output table
+    $RepositoryTags = az acr repository show-tags --name $AzureRegistryName --repository $RepositoryName --orderby time_desc --output tsv
 
-    for($item=2; $item -lt $RepositoryTags.length; $item++){
-        $RepositoryTagName = $RepositoryTags[$item].ToString().Split('_')        
-
-        $RepositoryTagBuildDay = $RepositoryTagName[-1].ToString().Split('.')[0]
-        if($RepositoryTagBuildDay -eq "latest"){
-            Write-Host "Skipping image: $RepositoryName/latest"
-            continue;
+    # Delete by count if user specified a $NoOfKeptImages
+    if ($NoOfKeptImages -gt 0){
+        #since the list is ordered, delete the last X items
+        foreach($tag in $RepositoryTags){
+            if($RepositoryTags.IndexOf($tag) -ge $NoOfKeptImages){
+                $ImageName = $RepositoryName + ":" + $tag
+                Remove-Image -registryName $RepositoryName -imageName $ImageName -dryRun $DryRun
+            }
         }
+    }
+    # Delete by the age of the label (assuming yyyyMMdd convention in the tag names)
+    else {
+        foreach($tag in $RepositoryTags){
+            $RepositoryTagName = $tag.ToString().Split('_')        
 
-        $RepositoryTagBuildDay = [datetime]::ParseExact($repositorytagbuildday,'yyyyMMdd', $null)
-        $ImageName = $RepositoryName + ":" + $RepositoryTags[$item]
+            $RepositoryTagBuildDay = $RepositoryTagName[-1].ToString().Split('.')[0]
+            if($RepositoryTagBuildDay -eq "latest"){
+                Write-Host "Skipping image: $RepositoryName/latest"
+                continue;
+            }
 
-        if($RepositoryTagBuildDay -lt $((Get-Date).AddDays(-$NoOfDays))){
-            Write-Host "Proceeding to delete image: $ImageName"
-            az acr repository delete --name $AzureRegistryName --image $ImageName --yes
-        }        
-        else{
-            Write-Host "Skipping image: $ImageName"
+            $RepositoryTagBuildDay = [datetime]::ParseExact($repositorytagbuildday,'yyyyMMdd', $null)
+            $ImageName = $RepositoryName + ":" + $tag
+
+            if($RepositoryTagBuildDay -lt $((Get-Date).AddDays(-$NoOfDays))){
+                Remove-Image -registryName $RepositoryName -imageName $ImageName -dryRun $DryRun
+            }        
+            else{
+                Write-Host "Skipping image: $ImageName"
+            }
         }
     }
 }


### PR DESCRIPTION
I wanted the ability to be able to keep X number of images (discard all but the most recent X).  Our repos don't follow the date convention, and would rather delete based on age than naming convention.  I added it as an optional parameter so it's an either/or situation between the NoOfDays and NoOfKeptImages arguments.  I think it could be a cleaner delineation in the code but I wanted to make the comparison easier so I just branched with an if.

I also added a DryRun boolean arg, so the script output could be seen without taking action on the images.

Looking for feedback or thoughts.  Happy to adjust to suit.