### PR TITLE
ci: docker build and publish to github packages

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,62 @@
+name: Push Docker Image
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker tag'
+        required: true
+        default: 'latest' 
+        type: string
+
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  # IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build-push:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - id: imagename
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ github.repository }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ./image-updater/source-code
+          file: ./image-updater/source-code/Dockerfile
+          push: true
+          tags: ghcr.io/${{ steps.imagename.outputs.lowercase }}:${{ inputs.docker_tag }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,19 +1,11 @@
-name: Push Docker Image
+name: Build Docker
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
 
-on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-    inputs:
-      docker_tag:
-        description: 'Docker tag'
-        required: true
-        default: 'latest' 
-        type: string
+on: [push]
 
 
 env:
@@ -56,7 +48,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
-          context: ./image-updater/source-code
-          file: ./image-updater/source-code/Dockerfile
+          context: .
+          file: Dockerfile
           push: true
-          tags: ghcr.io/${{ steps.imagename.outputs.lowercase }}:${{ inputs.docker_tag }}
+          tags: ghcr.io/${{ steps.imagename.outputs.lowercase }}:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,8 +5,15 @@ name: Build Docker
 # separate terms of service, privacy policy, and support
 # documentation.
 
-on: [push]
-
+on:
+    push:
+      branches:
+        - master
+        - main
+    pull_request:
+        branches:    
+          - main
+          - master
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
I took the liberty to contribute to this project as my friend @Vinaum8 asked me to create a pipeline for building the Docker image using GitHub Actions. So, I made this small contribution towards it.

The development process is simple: with every change in the master/main branch, a new container image will be generated with the "latest" tag. Since it's stable and doesn't require robust versioning control, I believe it's suitable for the current needs.

I'm open to any suggestions or changes regarding it.

Thank you,


To example how the job works see this job link: [reference actions](https://github.com/Gustavmk/acr-cleanup/actions/runs/5967542966)